### PR TITLE
docs: refresh readme with usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,79 @@
 # Chestnut
 
-Chestnut – Track any block in Minecraft and send custom Discord webhook alerts when it’s opened, toggled, or changes state.
+Chestnut is a friendly Minecraft plugin that watches specific blocks and
+sends Discord messages when something happens to them. Use it to keep an eye
+on mailboxes, doors, torches and more.
 
 ## Features
-- Track a specific block location with a chosen trigger (INVENTORY_OPEN, TORCH_TOGGLE, LECTERN)
-- Custom per-event message templates with placeholders
-- Async Discord webhook delivery with rate limits and retries
-- Debounce to avoid spam
-- Simple persistence to trackers.yml
+
+- Track any block by standing next to it and running a command.
+- Built‑in triggers such as `INVENTORY_OPEN`, `TORCH_TOGGLE` and `LECTERN`.
+- Custom message templates with placeholders like `<name>` or `<world>`.
+- Optional embed colors and thumbnail images for each event.
+- Discord webhooks sent asynchronously with rate limiting and retry.
+
+## Installation
+
+1. Build the plugin with `./gradlew build` or download a release jar.
+2. Drop the jar into your server's `plugins` folder and restart.
+3. Edit `plugins/Chestnut/config.yml` and set `webhookUrl` to your Discord webhook.
 
 ## Commands
-- /trackerlist [page] (alias: /trackers)
-- /settracker <name> <trigger>
-- /deltracker <name|all> [--confirm]
-- /edittracker <name> <rename|title|description|msg|rebind|enable|disable|test|tp|info|color|thumbnail>
-- /chestnut <help|reload|status>
 
-Permissions:
-- chestnut.use
-- chestnut.admin
+| Command | Description |
+| --- | --- |
+| `/settracker <name> <trigger>` | Bind the block you're looking at to a tracker. |
+| `/edittracker <name> …` | Change messages, colors, thumbnails and more. |
+| `/trackerlist [page]` | Show all trackers. |
+| `/deltracker <name\|all>` | Remove trackers. |
+| `/chestnut <help\|reload\|status>` | Administrative actions. |
 
-## Config
-See `config.yml` for settings like webhookUrl, testPrefix, globalRateLimitPerMinute, defaultDebounceTicks, includeItemsByDefault, enableTestCommand, debug.
+## Trigger Reference
+
+All triggers support basic tags like `<name>`, `<trigger>`, `<event>`, `<world>`, `<x>`, `<y>`, `<z>` and `<time>`. Some triggers add extra tags listed below.
+
+| Trigger | States | Extra tags |
+| --- | --- | --- |
+| `INVENTORY_OPEN` (Storage) | `open`, `close` | `<user>`, `<uuid>`, `<items>` |
+| `TORCH_TOGGLE` (Redstone Torch) | `on`, `off` | `<state>` (`lit` or `unlit`) |
+| `LECTERN` (Lectern) | `insert_book`, `remove_book`, `page_change`, `open` | `<user>`, `<uuid>`, `<page>`, `<book_title>`, `<book_author>`, `<book_pages>`, `<has_book>` |
+
+## Example: Monitoring a Mailbox
+
+Imagine a chest at spawn where players drop off items. You want a Discord alert
+whenever it is opened.
+
+1. Stand in front of the chest and run:
+   ```
+   /settracker mailbox INVENTORY_OPEN
+   ```
+2. Customize the messages sent to Discord:
+   ```
+   /edittracker mailbox msg open "<name> checked the mailbox!"
+   /edittracker mailbox msg close "<name> closed the mailbox."
+   ```
+3. Add some color and icons:
+   ```
+   /edittracker mailbox color open #00FF00
+   /edittracker mailbox color close #FF0000
+   /edittracker mailbox thumbnail open https://example.com/open.png
+   /edittracker mailbox thumbnail close https://example.com/close.png
+   ```
+4. Try it out with a test event:
+   ```
+   /edittracker mailbox test open
+   ```
+
+Now every time the chest is used, an embed will be posted to your webhook with
+the configured title, description, color and thumbnail.
+
+## Permissions
+
+- `chestnut.use` – Allows players to create and manage trackers.
+- `chestnut.admin` – Grants access to admin commands like reload.
+
+## Configuration
+
+`config.yml` contains global settings such as the default embed color, webhook
+URL and rate limits. The file includes comments for each option.
+


### PR DESCRIPTION
## Summary
- Rewrite README with friendly overview and feature list
- Add step-by-step example demonstrating tracker setup and embed customization
- Document trigger states and extra tags in a new reference table

## Testing
- `bash ./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689853c4704c8325a83db0c6c534fdb6